### PR TITLE
Changing quill-async to quill-jasync

### DIFF
--- a/unit7/lesson46/build.sbt
+++ b/unit7/lesson46/build.sbt
@@ -5,7 +5,7 @@ version := "0.1"
 scalaVersion := "2.13.4" // waiting on quill to upgrade to scala 3
 
 libraryDependencies ++= List(
-  "io.getquill" %% "quill-async-postgres" % "3.5.2",
+  "io.getquill" %% "quill-jasync-postgres" % "3.7.0",
   "org.testcontainers" % "postgresql" % "1.13.0",
   "org.postgresql" % "postgresql" % "42.2.11",
   "ch.qos.logback"  %  "logback-classic" % "1.2.3"

--- a/unit7/lesson46/src/main/scala/org/example/registrations/CustomerQueries.scala
+++ b/unit7/lesson46/src/main/scala/org/example/registrations/CustomerQueries.scala
@@ -1,22 +1,22 @@
 package org.example.registrations
 
-import io.getquill.{PostgresAsyncContext, SnakeCase}
+import io.getquill.{PostgresJAsyncContext, SnakeCase}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class Customer(id: Int, name: String)
 
-class CustomerQueries(ctx: PostgresAsyncContext[SnakeCase.type]) {
+class CustomerQueries(ctx: PostgresJAsyncContext[SnakeCase.type]) {
   import ctx._
 
   private val customers = quote { query[Customer] }
 
-  def all()(implicit ec: ExecutionContext): Future[List[Customer]] = {
+  def all()(implicit ec: ExecutionContext): Future[Seq[Customer]] = {
     // Generated SQL: SELECT x.id, x.name FROM customer x
     run(customers)
   }
 
   def nameById(id: Int)
-              (implicit ec: ExecutionContext): Future[List[String]] = {
+              (implicit ec: ExecutionContext): Future[Seq[String]] = {
     // Generated SQL: SELECT x1.name FROM customer x1 WHERE x1.id = ?
     val q = quote {
       customers.filter(_.id == lift(id))

--- a/unit7/lesson46/src/main/scala/org/example/registrations/Queries.scala
+++ b/unit7/lesson46/src/main/scala/org/example/registrations/Queries.scala
@@ -1,9 +1,9 @@
 package org.example.registrations
 
-import io.getquill.{PostgresAsyncContext, SnakeCase}
+import io.getquill.{PostgresJAsyncContext, SnakeCase}
 import scala.concurrent.{ExecutionContext, Future}
 
-class Queries(ctx: PostgresAsyncContext[SnakeCase.type]) {
+class Queries(ctx: PostgresJAsyncContext[SnakeCase.type]) {
   import ctx._
 
   def testConnection()(implicit ec: ExecutionContext): Future[Boolean] = {

--- a/unit7/lesson46/src/main/scala/org/example/registrations/TestDatabase.scala
+++ b/unit7/lesson46/src/main/scala/org/example/registrations/TestDatabase.scala
@@ -1,11 +1,11 @@
 package org.example.registrations
 
-import io.getquill.{PostgresAsyncContext, SnakeCase}
+import io.getquill.{PostgresJAsyncContext, SnakeCase}
 
 object TestDatabase {
 
   private val psqlServer = new PostgreSQL("init.sql")
-  val ctx = new PostgresAsyncContext(SnakeCase, psqlServer.config)
+  val ctx = new PostgresJAsyncContext(SnakeCase, psqlServer.config)
 
   def stop(): Unit = psqlServer.stop()
 }

--- a/unit7/lesson46/src/main/scala/quickchecks/QuickCheck-46.1.sc
+++ b/unit7/lesson46/src/main/scala/quickchecks/QuickCheck-46.1.sc
@@ -14,4 +14,4 @@
 // ANSWER
 
 import io.getquill._
-new PostgresAsyncContext(CamelCase, "db")
+new PostgresJAsyncContext(CamelCase, "db")

--- a/unit7/lesson46/src/main/scala/quickchecks/QuickCheck-46.2.sc
+++ b/unit7/lesson46/src/main/scala/quickchecks/QuickCheck-46.2.sc
@@ -9,7 +9,7 @@ import io.getquill.Query
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-val customers: Future[List[String]] = run(quote {
+val customers: Future[Seq[String]] = run(quote {
   infix"SELECT name FROM customer".as[Query[String]]
 })
 
@@ -25,27 +25,27 @@ val customers: Future[List[String]] = run(quote {
 //      | import scala.concurrent.Future
 //      |
 //      |
-//      | val customers: Future[List[String]] = run(quote {
+//      | val customers: Future[Seq[String]] = run(quote {
 //      |   infix"SELECT name FROM customers".as[Query[String]]
 //      | })
-// val customers: Future[List[String]] = run(quote {
+// val customers: Future[Seq[String]] = run(quote {
 //   ^
 //   <pastie>:7: SELECT x.* FROM (SELECT name FROM customers) AS x
 //     import org.example.registrations._
 //     import TestDatabase.ctx._
 //     import scala.concurrent.Future
 //     import scala.concurrent.ExecutionContext.Implicits.global
-//     customers: scala.concurrent.Future[List[String]] = Future(<not completed>)
+//     customers: scala.concurrent.Future[Seq[String]] = Future(<not completed>)
 //     Error with message -> ErrorMessage(fields=HashMap(Position -> 35, Line -> 1160, V -> ERROR, Message -> relation "customers" does not exist, Severity -> ERROR, File -> parse_relation.c, SQLSTATE -> 42P01, Routine -> parserOpenTable))
 
 // If you correct your query, you code will return the name of the three customers in your database:
 
-// scala> val customers: Future[List[String]] = run(quote{
+// scala> val customers: Future[Seq[String]] = run(quote{
 //   | infix"SELECT name FROM customer".as[Query[String]] } )
 // ^
 // SELECT x.* FROM (SELECT name FROM customer) AS x
-// res0: Future[List[String]] =
-// Future(Success(List(Jon Snow, Daenerys Targaryen, Arya Stark)))
+// res0: Future[Seq[String]] =
+// Future(Success(Seq(Jon Snow, Daenerys Targaryen, Arya Stark)))
 //
 // Note that the snippet of code used as[Query[String]] instead of as[String]
 // because the query returns zero or more records, rather than exactly one.

--- a/unit7/lesson46/src/main/scala/quickchecks/QuickCheck-46.3.sc
+++ b/unit7/lesson46/src/main/scala/quickchecks/QuickCheck-46.3.sc
@@ -1,23 +1,23 @@
 // Add a function customersByName to your class CustomerQueries to generate and run
 // a query to retrieve customers with a given name.
 
-// def customersByName(name: String): List[Customer] = ???
+// def customersByName(name: String): Seq[Customer] = ???
 
 
 // ANSWER
 
-import io.getquill.{PostgresAsyncContext, SnakeCase}
+import io.getquill.{PostgresJAsyncContext, SnakeCase}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class Customer(id: Int, name: String)
 
-class CustomerQueries(ctx: PostgresAsyncContext[SnakeCase.type]) {
+class CustomerQueries(ctx: PostgresJAsyncContext[SnakeCase.type]) {
   import ctx._
 
   private val customers = quote { query[Customer] }
 
   def customersByName(name: String)
-                     (implicit ec: ExecutionContext): Future[List[Customer]] = {
+                     (implicit ec: ExecutionContext): Future[Seq[Customer]] = {
     val q = quote { customers.filter(_.name == lift(name)) }
     run(q)
   }

--- a/unit7/lesson46/src/main/scala/trythis/TryThis-46.1.sc
+++ b/unit7/lesson46/src/main/scala/trythis/TryThis-46.1.sc
@@ -18,13 +18,13 @@
 
 import java.time.LocalDate
 
-import io.getquill.{PostgresAsyncContext, SnakeCase}
+import io.getquill.{PostgresJAsyncContext, SnakeCase}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class Customer(id: Int, name: String)
 case class Product(id: Int, title: String, creationDate: LocalDate)
 
-class ProductQueries(ctx: PostgresAsyncContext[SnakeCase.type]) {
+class ProductQueries(ctx: PostgresJAsyncContext[SnakeCase.type]) {
   import ctx._
 
   private val products = quote { query[Product] }
@@ -36,7 +36,7 @@ class ProductQueries(ctx: PostgresAsyncContext[SnakeCase.type]) {
   }
 
   def allByTitle(title: String)
-                (implicit ec: ExecutionContext): Future[List[Product]] = {
+                (implicit ec: ExecutionContext): Future[Seq[Product]] = {
     val q = quote { products.filter(_.title == lift(title)) }
     run(q)
   }


### PR DESCRIPTION
Quill Async modules are based on a deprecated library called jasync by mauricio:
https://github.com/mauricio/postgresql-async

This library has been overhauled and is now maintained here:
https://github.com/jasync-sql/jasync-sql 

Besides for the build.sbt dependency, `PostgresAsyncContext` had to be changed to `PostgresJAsyncContext` and `Future[List[T]]` return types had to be changed to `Future[Seq[T]]`.