### PR TITLE
[QuickCheck 10.3] cost should be def, not var

### DIFF
--- a/unit2/lesson10/src/main/scala/quickchecks/QuickCheck-10.3.sc
+++ b/unit2/lesson10/src/main/scala/quickchecks/QuickCheck-10.3.sc
@@ -14,7 +14,7 @@ class Party extends Event {
 
   private var attendees = 0
 
-  var cost = estimateCosts(attendees)
+  def cost = estimateCosts(attendees)
 
   def register(guests: Int) =
     attendees += guests


### PR DESCRIPTION
Fixes #98 also for the quick check